### PR TITLE
Feature Multiple GPU Training

### DIFF
--- a/src/data/dataloader.py
+++ b/src/data/dataloader.py
@@ -6,6 +6,8 @@ import random
 from natsort import natsorted
 os.environ['KMP_DUPLICATE_LIB_OK'] = 'True'
 
+from torch.utils.data.distributed import DistributedSampler
+
 
 class DemandDataset(torch.utils.data.Dataset):
     def __init__(self, data_dir, cut_len=16000*2):
@@ -56,9 +58,11 @@ def load_data(ds_dir, batch_size, n_cpu, cut_len):
     train_ds = DemandDataset(train_dir, cut_len)
     test_ds = DemandDataset(test_dir, cut_len)
 
-    train_dataset = torch.utils.data.DataLoader(dataset=train_ds, batch_size=batch_size, shuffle=True,
+    train_dataset = torch.utils.data.DataLoader(dataset=train_ds, batch_size=batch_size, pin_memory=True, shuffle=False,
+                                                sampler=DistributedSampler(train_ds), 
                                                 drop_last=True, num_workers=n_cpu)
-    test_dataset = torch.utils.data.DataLoader(dataset=test_ds, batch_size=batch_size, shuffle=False,
+    test_dataset = torch.utils.data.DataLoader(dataset=test_ds, batch_size=batch_size, pin_memory=True, shuffle=False,
+                                                sampler=DistributedSampler(test_ds), 
                                                drop_last=False, num_workers=n_cpu)
 
     return train_dataset, test_dataset


### PR DESCRIPTION
# Feature : 
**Training deep learning models on more than one GPU saves a lot of training time**. Any computer with multiple GPUs can distribute the load of training across all its GPUs to increase the amount of computation. CMGAN Model uses a single GPU for training. **It will save a lot of training time if we can train CMGAN Model on multiple GPUS**.

So, thinking of this reason I have implemented this feature by using **Distributed Data Parallel (DDP) present in pytorch.**

# Implementation Details: 

Two files, `src/train.py` and `src/data/dataloader.py` were modified in order to implement this feature. 

### Changes in `src/train.py`:

The following import statements are added in this file: 
```
import torch.multiprocessing as mp
from torch.nn.parallel import DistributedDataParallel as DDP
from torch.distributed import init_process_group, destroy_process_group
```

`mp` is used to  **spawn multiple processes** and **create a single DDP instance per process**. Each GPU runs a process. `DDP` is a **wrapper that is used on the model**. `init_process_group` is used to **initialise distributed process group**. `destroy_process_group` is used to **cleanly exit our DDP training**. 

A function `ddp_step `is implemented to **initialise distributed process group**. It accepts a GPU ID (`rank`) and number of cuda GPUs avaiable (`world_size`) as argument. 

In `__init__ `function of `trainer` class a new argument, `gpu_id` is added which is used to initialise `self.gpu_id`. `self.gpu_id `is used refer to an ID given to a GPU on which the object of trainer class is created. `self.model` and `self.discriminator` are wrapped using DDP.

In `train_step` function and `test_step` function of `trainer` class each tensor which was moved to the **cuda memory** using `.cuda()` function is replaced by `.to(self.gpu_id)` function, this loads the tensor to the **cuda memory of the GPU having a ID equal to** `self.gpu_id`.

In `test` function and `train` function of `trainer` class `self.gpu_id` is added to `template` in order to distinguish **logs or outputs from different GPUs**. 

In `train` function of `trainer` class, `if self.gpu_id==0:` condition is added before saving `state_dict` of the model this is done to prevent other GPUs from saving the same model (all GPUs have the same instance of the model with same weights and optimizer with same random seed). The first GPU has ID 0, so in this condition only the first GPU will be saving the model's `state_dict`. 

In main function new arguments, `rank` and `world_size` are passed. `rank` is the ID of GPU and `world_size` is total number of GPUs avaiable in the machine. `ddp_setup` function is called at the begining of this function to initialise the distributed process group and at end `destroy_process_group` function is called to cleanly exit the DDP training. A condition `if rank==0:` is added so that the first GPU prints args and avaiable GPUs which prevents other GPUs from printing the same output. 

Inside the `if __name__ == '__main__':` condition a variable name `world_size` is made which is the **total number of avaible GPUs** for training. `mp.spawn `function is called to **spawn multiple processes for training** and create a single DDP instance per process.

### Changes in `src/data/dataloader.py`:

The following import statement is added in the file:
`from torch.utils.data.distributed import DistributedSampler`

`DistributedSampler` takes in our **input data and distributes it across all the GPUs without any overlapping**.

The following arguments, `pin_memory=True`, `shuffle=False`, `sampler=DistributedSampler()` were passed to `torch.utils.data.DataLoader` while creating `train_dataset` and `test_dataset`.